### PR TITLE
Ap 9912 - Correcting typo in yaml format for HU division file

### DIFF
--- a/lib/countries/data/subdivisions/HU.yaml
+++ b/lib/countries/data/subdivisions/HU.yaml
@@ -1665,7 +1665,9 @@ SD:
     max_longitude: 20.3085971
   name: Szeged
 SF:
-  unofficial_names: Székesfehérvár
+  unofficial_names:
+  - Székesfehérvár
+  - Fehérvár
   translations:
     ar: سيكشفهيرفار
     be: Горад Секешфехервар
@@ -1676,7 +1678,7 @@ SF:
     da: Székesfehérvár
     de: Székesfehérvár
     el: Σεκεσφεχερβάρ
-    en: Székesfehérváren: Székesfehérvár
+    en: Székesfehérvár
     es: Székesfehérvár
     et: Székesfehérvár
     eu: Székesfehérvár

--- a/lib/countries/data/subdivisions/PL.yaml
+++ b/lib/countries/data/subdivisions/PL.yaml
@@ -1009,9 +1009,9 @@
     ur: مغربی پومرانیا صوبہ
     vi: Zachodniopomorskie
   geo:
-    latitude: 53.46578909999999
+    latitude: 53.4657890999999
     longitude: 15.1822581
-    min_latitude: 52.62466939999999
+    min_latitude: 52.6246693999999
     min_longitude: 14.1223531
     max_latitude: 54.5690916
     max_longitude: 16.9822089


### PR DESCRIPTION
Used an atom plugin to ensure only one error existed in file, it has been corrected and now the file is a valid yaml file.