### PR TITLE
AP-11064 - Stop prefixing msts norway country codes with `NO-`

### DIFF
--- a/lib/countries/data/subdivisions/NO.yaml
+++ b/lib/countries/data/subdivisions/NO.yaml
@@ -1,258 +1,6 @@
 ---
-NO-01:
-  unofficial_names: Østfold
-  translations:
-    en: Østfold
-  geo:
-    latitude: 59.25582859999999
-    longitude: 11.3279007
-    min_latitude: 58.8768946
-    min_longitude: 10.5764046
-    max_latitude: 59.79051459999999
-    max_longitude: 11.9460045
-  name: Østfold
-NO-02:
-  unofficial_names: Akershus
-  translations:
-    en: Akershus
-  geo:
-    latitude: 60.00002019999999
-    longitude: 11.3690301
-    min_latitude: 59.4718821
-    min_longitude: 10.3290796
-    max_latitude: 60.59664780000001
-    max_longitude: 11.9260507
-  name: Akershus
-NO-03:
-  unofficial_names: Oslo
-  translations:
-    en: Oslo
-  geo:
-    latitude: 59.9138688
-    longitude: 10.7522454
-    min_latitude: 59.8096749
-    min_longitude: 10.6225688
-    max_latitude: 59.978035
-    max_longitude: 10.9476642
-  name: Oslo
-NO-04:
-  unofficial_names: Hedmark
-  translations:
-    en: Hedmark
-  geo:
-    latitude: 61.3967311
-    longitude: 11.5627369
-    min_latitude: 59.84135440000001
-    min_longitude: 9.5838267
-    max_latitude: 62.6969236
-    max_longitude: 12.8708487
-  name: Hedmark
-NO-05:
-  unofficial_names: Oppland
-  translations:
-    en: Oppland
-  geo:
-    latitude: 61.5422752
-    longitude: 9.716631399999999
-    min_latitude: 60.13160989999999
-    min_longitude: 7.3425305
-    max_latitude: 62.37840250000001
-    max_longitude: 11.1327999
-  name: Oppland
-NO-06:
-  unofficial_names: Buskerud
-  translations:
-    en: Buskerud
-  geo:
-    latitude: 60.48460249999999
-    longitude: 8.698376399999999
-    min_latitude: 59.4078708
-    min_longitude: 7.438842299999999
-    max_latitude: 61.0917205
-    max_longitude: 10.6192606
-  name: Buskerud
-NO-07:
-  unofficial_names: Vestfold
-  translations:
-    en: Vestfold
-  geo:
-    latitude: 59.17078619999999
-    longitude: 10.1144355
-    min_latitude: 58.8402834
-    min_longitude: 9.7553356
-    max_latitude: 59.6915912
-    max_longitude: 10.6001915
-  name: Vestfold
-NO-08:
-  unofficial_names: Telemark
-  translations:
-    en: Telemark
-  geo:
-    latitude: 59.39139849999999
-    longitude: 8.321121
-    min_latitude: 58.76740489999999
-    min_longitude: 7.0962874
-    max_latitude: 60.1882718
-    max_longitude: 9.895088099999999
-  name: Telemark
-NO-09:
-  unofficial_names: Aust-Agder
-  translations:
-    en: Aust-Agder
-  geo:
-    latitude: 58.66703039999999
-    longitude: 8.0844752
-    min_latitude: 58.1050135
-    min_longitude: 6.8245331
-    max_latitude: 59.6704093
-    max_longitude: 9.3693846
-  name: Aust-Agder
-NO-10:
-  unofficial_names: Vest-Agder
-  translations:
-    en: Vest-Agder
-  geo:
-    latitude: 58.368605
-    longitude: 6.901961600000001
-    min_latitude: 57.95849709999999
-    min_longitude: 6.3765277
-    max_latitude: 59.18884579999999
-    max_longitude: 8.2098324
-  name: Vest-Agder
-NO-11:
-  unofficial_names: Rogaland
-  translations:
-    en: Rogaland
-  geo:
-    latitude: 59.1489544
-    longitude: 6.0143431
-    min_latitude: 58.2776276
-    min_longitude: 4.844005999999999
-    max_latitude: 59.84433379999999
-    max_longitude: 7.2119667
-  name: Rogaland
-NO-12:
-  unofficial_names: Hordaland
-  translations:
-    en: Hordaland
-  geo:
-    latitude: 60.2733674
-    longitude: 5.7220194
-    min_latitude: 59.4759811
-    min_longitude: 4.6334781
-    max_latitude: 61.0352379
-    max_longitude: 7.732114699999999
-  name: Hordaland
-NO-14:
-  unofficial_names: Sogn og Fjordane
-  translations:
-    en: Sogn og Fjordane
-  geo:
-    latitude: 61.5539435
-    longitude: 6.3325879
-    min_latitude: 60.67554759999999
-    min_longitude: 4.5000011
-    max_latitude: 62.2168708
-    max_longitude: 8.3220528
-  name: Sogn og Fjordane
-NO-15:
-  unofficial_names: Møre og Romsdal
-  translations:
-    en: Møre og Romsdal
-  geo:
-    latitude: 62.9760369
-    longitude: 8.018272399999999
-    min_latitude: 61.9565835
-    min_longitude: 5.263584499999999
-    max_latitude: 63.5377568
-    max_longitude: 9.5842118
-  name: Møre og Romsdal
-NO-16:
-  unofficial_names: Sør-Trøndelag
-  translations:
-    en: Sør-Trøndelag
-  geo:
-    latitude: 63.0136823
-    longitude: 10.3487135
-    min_latitude: 62.2557267
-    min_longitude: 8.233780099999999
-    max_latitude: 64.4653999
-    max_longitude: 12.2467012
-  name: Sør-Trøndelag
-NO-17:
-  unofficial_names: Nord-Trøndelag
-  translations:
-    en: Nord-Trøndelag
-  geo:
-    latitude: 64.4370792
-    longitude: 11.7462949
-    min_latitude: 63.1806873
-    min_longitude: 10.1335962
-    max_latitude: 65.39440379999999
-    max_longitude: 14.3259858
-  name: Nord-Trøndelag
-NO-18:
-  unofficial_names: Nordland
-  translations:
-    en: Nordland
-  geo:
-    latitude: 67.69167019999999
-    longitude: 12.7019476
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Nordland
-NO-19:
-  unofficial_names: Troms
-  translations:
-    en: Troms
-  geo:
-    latitude: 69.81782419999999
-    longitude: 18.7819365
-    min_latitude: 68.3560138
-    min_longitude: 15.5925417
-    max_latitude: 70.31976139999999
-    max_longitude: 22.8944657
-  name: Troms
-NO-20:
-  unofficial_names:
-  - Finnmarku
-  translations:
-    en: Finnmark
-  geo:
-    latitude: 70.4830388
-    longitude: 26.0135108
-    min_latitude: 68.55459180000001
-    min_longitude: 21.173939
-    max_latitude: 71.1854762
-    max_longitude: 31.1682684
-  name: Finnmark
-NO-21:
-  unofficial_names: Svalbard (Arctic Region) (See also country code SJ)
-  translations:
-    en: Svalbard (Arctic Region) (See also country code SJ)
-  geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Svalbard (Arctic Region) (See also country code SJ)
-NO-22:
-  unofficial_names: Jan Mayen (Arctic Region) (See also country code SJ)
-  translations:
-    en: Jan Mayen (Arctic Region) (See also country code SJ)
-  geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Jan Mayen (Arctic Region) (See also country code SJ)
 '01':
+  unofficial_names: Østfold
   translations:
     af: Østfold
     ar: أوستفولد
@@ -307,7 +55,16 @@ NO-22:
     ur: اوستفول
     vi: Østfold
     zh: 东福尔郡
+  geo:
+    latitude: 59.25582859999999
+    longitude: 11.3279007
+    min_latitude: 58.8768946
+    min_longitude: 10.5764046
+    max_latitude: 59.79051459999999
+    max_longitude: 11.9460045
+  name: Østfold
 '02':
+  unofficial_names: Akershus
   translations:
     af: Akershus
     ar: آكرشوس
@@ -363,7 +120,16 @@ NO-22:
     uk: Акерсгус
     ur: آکیشوس
     vi: Akershus
+  geo:
+    latitude: 60.00002019999999
+    longitude: 11.3690301
+    min_latitude: 59.4718821
+    min_longitude: 10.3290796
+    max_latitude: 60.59664780000001
+    max_longitude: 11.9260507
+  name: Akershus
 '03':
+  unofficial_names: Oslo
   translations:
     af: Oslo
     am: ኦስሎ
@@ -427,7 +193,16 @@ NO-22:
     uk: Осло
     ur: اوسلو
     vi: Oslo
+  geo:
+    latitude: 59.9138688
+    longitude: 10.7522454
+    min_latitude: 59.8096749
+    min_longitude: 10.6225688
+    max_latitude: 59.978035
+    max_longitude: 10.9476642
+  name: Oslo
 '04':
+  unofficial_names: Hedmark
   translations:
     af: Hedmark
     ar: هيدمارك
@@ -480,7 +255,16 @@ NO-22:
     uk: Гедмарк
     ur: ہیڈمارک
     vi: Hedmark
+  geo:
+    latitude: 61.3967311
+    longitude: 11.5627369
+    min_latitude: 59.84135440000001
+    min_longitude: 9.5838267
+    max_latitude: 62.6969236
+    max_longitude: 12.8708487
+  name: Hedmark
 '05':
+  unofficial_names: Oppland
   translations:
     af: Oppland
     ar: أوبلاند
@@ -534,7 +318,16 @@ NO-22:
     uk: Опплан
     ur: اوپلان
     vi: Oppland
+  geo:
+    latitude: 61.5422752
+    longitude: 9.716631399999999
+    min_latitude: 60.13160989999999
+    min_longitude: 7.3425305
+    max_latitude: 62.37840250000001
+    max_longitude: 11.1327999
+  name: Oppland
 '06':
+  unofficial_names: Buskerud
   translations:
     af: Buskerud
     ar: بوسكرود
@@ -588,7 +381,16 @@ NO-22:
     uk: Бускерюд
     ur: بوسکرود
     vi: Buskerud
+  geo:
+    latitude: 60.48460249999999
+    longitude: 8.698376399999999
+    min_latitude: 59.4078708
+    min_longitude: 7.438842299999999
+    max_latitude: 61.0917205
+    max_longitude: 10.6192606
+  name: Buskerud
 '07':
+  unofficial_names: Vestfold
   translations:
     af: Vestfold
     ar: فستفولد
@@ -640,7 +442,114 @@ NO-22:
     uk: Вестфол
     ur: ویستفول
     vi: Vestfold
+  geo:
+    latitude: 59.17078619999999
+    longitude: 10.1144355
+    min_latitude: 58.8402834
+    min_longitude: 9.7553356
+    max_latitude: 59.6915912
+    max_longitude: 10.6001915
+  name: Vestfold
+'08':
+  unofficial_names: Telemark
+  translations:
+    ar: مقاطعة تلمارك
+    be: Тэлемарк
+    bg: Телемарк
+    ca: Telemark
+    cs: Telemark
+    da: Telemarken
+    de: Telemark
+    en: Telemark
+    es: Telemark
+    et: Telemark
+    eu: Telemark
+    fa: تلمارک
+    fi: Telemarkin lääni
+    fr: Comté de Telemark
+    hr: Telemark
+    hu: Telemark megye
+    id: Telemark
+    is: Þelamörk
+    it: Telemark
+    ja: テレマルク県
+    ka: ტელემარკი
+    ko: 텔레마르크 주
+    lt: Telemarkas
+    nb: Telemark
+    nl: Telemark
+    pl: Telemark
+    pt: Telemark
+    ro: Telemark
+    ru: Телемарк
+    sk: Telemark
+    sl: Telemark
+    sr: Телемарк
+    sv: Telemark fylke
+    ta: டெலிமார்க்
+    tr: Telemark
+    uk: Телемарк
+    ur: تیلیمارک
+    vi: Telemark
+  geo:
+    latitude: 59.39139849999999
+    longitude: 8.321121
+    min_latitude: 58.76740489999999
+    min_longitude: 7.0962874
+    max_latitude: 60.1882718
+    max_longitude: 9.895088099999999
+  name: Telemark
+'09':
+  unofficial_names: Aust-Agder
+  translations:
+    ar: أوست أغدر
+    be: Эўст-Агдэр
+    bg: Ауст-Агдер
+    ca: Aust-Agder
+    cs: Aust-Agder
+    da: Aust-Agder
+    de: Aust-Agder
+    en: Aust-Agder
+    es: Aust-Agder
+    et: Aust-Agder
+    eu: Aust-Agder
+    fa: اوست آدر
+    fi: Itä-Agderin lääni
+    fr: Comté d’Aust-Agder
+    hr: Aust-Agder
+    hu: Aust-Agder megye
+    id: Aust-Agder
+    is: Austur-Agðir
+    it: Aust-Agder
+    ja: アウスト・アグデル県
+    ka: ეუსტ-აგდერი
+    ko: 에우스트아그데르 주
+    lt: Rytų Agderis
+    nb: Aust-Agder
+    nl: Aust-Agder
+    pl: Aust-Agder
+    pt: Aust-Agder
+    ro: Aust-Agder
+    ru: Эуст-Агдер
+    sk: Aust-Agder
+    sl: Aust-Agder
+    sr: Источни Агдер
+    sv: Aust-Agder fylke
+    sw: Aust-Agder
+    tr: Aust-Agder
+    uk: Еуст-Аґдер
+    ur: آوست-آگدیر
+    vi: Aust-Agder
+  geo:
+    latitude: 58.66703039999999
+    longitude: 8.0844752
+    min_latitude: 58.1050135
+    min_longitude: 6.8245331
+    max_latitude: 59.6704093
+    max_longitude: 9.3693846
+  name: Aust-Agder
 '10':
+  unofficial_names: Vest-Agder
   translations:
     af: Vest-Agder
     ar: فست أغدر
@@ -691,7 +600,68 @@ NO-22:
     uk: Вест-Аґдер
     ur: ویست-آگدیر
     vi: Vest-Agder
+  geo:
+    latitude: 58.368605
+    longitude: 6.901961600000001
+    min_latitude: 57.95849709999999
+    min_longitude: 6.3765277
+    max_latitude: 59.18884579999999
+    max_longitude: 8.2098324
+  name: Vest-Agder
+'11':
+  unofficial_names: Rogaland
+  translations:
+    ar: روغالاند
+    be: Ругалан
+    bg: Ругалан
+    ca: Rogaland
+    cs: Rogaland
+    da: Rogaland
+    de: Rogaland
+    en: Rogaland
+    es: Rogaland
+    et: Rogaland
+    eu: Rogaland
+    fa: روگالاند
+    fi: Rogalandin lääni
+    fr: comté de Rogaland
+    he: רוגלנד
+    hr: Rogaland
+    hu: Rogaland megye
+    hy: Ռուգլան
+    id: Rogaland
+    is: Rogaland
+    it: Rogaland
+    ja: ローガラン県
+    ka: რუგალანი
+    ko: 로갈란 주
+    lt: Rugalandas
+    lv: Rūgalanne
+    nb: Rogaland
+    nl: Rogaland
+    pl: Rogaland
+    pt: Rogaland
+    ro: Rogaland
+    ru: Ругаланн
+    sk: Rogaland
+    sl: Rogaland
+    sr: Рогаланд
+    sv: Rogaland fylke
+    sw: Rogaland
+    tr: Rogaland
+    uk: Руґалан
+    ur: روگالان
+    vi: Rogaland
+  geo:
+    latitude: 59.1489544
+    longitude: 6.0143431
+    min_latitude: 58.2776276
+    min_longitude: 4.844005999999999
+    max_latitude: 59.84433379999999
+    max_longitude: 7.2119667
+  name: Rogaland
 '12':
+  unofficial_names: Hordaland
   translations:
     af: Hordaland
     ar: هوردالان
@@ -747,391 +717,16 @@ NO-22:
     uk: Гордалан
     ur: ہوردالان
     vi: Hordaland
-'18':
-  translations:
-    af: Nordland
-    ar: نورلان
-    be: Нурлан
-    bg: Норлан
-    bn: নর্ডল্যান্ড
-    ca: Nordland
-    cs: Nordland
-    da: Nordland
-    de: Nordland
-    el: Νόρντλαντ
-    en: Nordland
-    es: Nordland
-    et: Nordland
-    eu: Nordland
-    fa: نوردلند
-    fi: Nordlandin lääni
-    fr: comté de Nordland
-    gu: નોર્ડલેન્ડ
-    hi: नोर्डलैंड
-    hr: Nordland
-    hu: Nordland megye
-    hy: Նուռլան
-    id: Nordland
-    is: Norðurland
-    it: Nordland
-    ja: ヌールラン県
-    ka: ნურლანი
-    kn: ನಾರ್ಡ್ಲ್ಯಾಂಡ್
-    ko: 노를란 주
-    lt: Nordlandas
-    lv: Nūrlanne
-    mr: नोर्डंड
-    ms: Nordland
-    nb: Nordland
-    nl: Nordland
-    pl: Nordland
-    pt: Nordland
-    ro: Nordland
-    ru: Нурланн
-    si: නොර්ඩ්ලන්ඩ්
-    sk: Nordland
-    sl: Nordland
-    sr: Нордланд
-    sv: Nordland fylke
-    sw: Nordland
-    te: నార్డ్‌లాండ్
-    th: นอร์ดแลนด์
-    tr: Nordland
-    uk: Нурлан
-    ur: نودلان
-    vi: Nordland
-'19':
-  translations:
-    af: Troms
-    ar: ترومس
-    be: Тромс
-    bg: Тромс
-    bn: ট্রোমস
-    ca: Troms
-    cs: Troms
-    da: Troms
-    de: Troms
-    el: Τρομς
-    en: Troms
-    es: Troms
-    et: Troms
-    eu: Troms
-    fa: ترومز
-    fi: Tromssan lääni
-    fr: Troms
-    gu: ટ્રોમ્સ
-    hi: ट्रोम्स
-    hr: Troms
-    hu: Troms megye
-    hy: Թրոմս
-    id: Troms
-    is: Tromsfylki
-    it: Troms
-    ja: トロムス県
-    ka: ტრომსი
-    kn: ಟ್ರೋಮ್ಸ್
-    ko: 트롬스 주
-    lt: Trumsas
-    lv: Trumse
-    mr: ट्रॉम्स
-    ms: Troms
-    nb: Troms
-    nl: Troms
-    pl: Troms
-    pt: Troms
-    ro: Troms
-    ru: Тромс
-    si: ට්‍රොම්ස්
-    sk: Troms
-    sl: Troms
-    sr: Тромс
-    sv: Troms fylke
-    ta: ட்ரோம்ஸ்
-    te: ట్రోమ్స్
-    th: ตรอมส์
-    tr: Troms
-    uk: Трумс
-    ur: ترومس
-    vi: Troms
-'20':
-  translations:
-    af: Finnmark
-    ar: فينمارك
-    be: Фінмарк
-    bg: Финмарк
-    ca: Finnmark
-    cs: Finnmark
-    da: Finnmark
-    de: Finnmark
-    en: Finnmark
-    es: Finnmark
-    et: Finnmark
-    eu: Finnmark
-    fa: فینمارک
-    fi: Finnmarkin lääni
-    fr: comté de Finnmark
-    he: פינמרק
-    hr: Finnmark
-    hu: Finnmark megye
-    hy: Ֆինմարք
-    id: Finnmark
-    is: Finnmörk
-    it: Finnmark
-    ja: フィンマルク県
-    ka: ფინმარკი
-    ko: 핀마르크 주
-    lt: Finmarkas
-    lv: Finnmarka
-    nb: Finnmark
-    nl: Finnmark
-    pl: Finnmark
-    pt: Finnmark
-    ro: Finnmark
-    ru: Финнмарк
-    sk: Finnmark
-    sl: Finnmark
-    sr: Финмарк
-    sv: Finnmark fylke
-    sw: Finnmark
-    th: เทศมณฑลฟินน์มาร์ก
-    tr: Finnmark
-    uk: Фінмарк
-    ur: فنمارک
-    vi: Finnmark
-'21':
-  translations:
-    af: Svalbard
-    ar: سفالبارد
-    az: Şpisbergen
-    be: Шпіцберген
-    bg: Шпицберген
-    bn: স্বালবার্ড
-    ca: Svalbard
-    cs: Špicberky
-    da: Svalbard
-    de: Spitzbergen
-    el: Αρχιπέλαγος Σβάλμπαρντ
-    en: Svalbard
-    es: Svalbard
-    et: Svalbard
-    eu: Svalbard
-    fa: سوالبارد
-    fi: Huippuvuoret
-    fr: Svalbard
-    gl: Svalbard
-    gu: સ્વાલબાર્ડ
-    he: סבאלברד
-    hi: स्वालबार्ड
-    hr: Svalbard
-    hu: Spitzbergák
-    hy: Շպիցբերգեն
-    id: Svalbard
-    is: Svalbarði
-    it: Isole Svalbard
-    ja: スヴァールバル諸島
-    ka: შპიცბერგენი
-    kn: ಸ್ವಾಲ್ಬಾರ್ಡ್
-    ko: 스발바르 제도
-    lt: Svalbardas
-    lv: Svalbāra
-    ml: സ്വാൽബാർഡ്
-    mr: स्वालबार्ड
-    ms: Svalbard
-    nb: Svalbard
-    nl: Spitsbergen
-    pl: Svalbard
-    pt: Svalbard
-    ro: Svalbard
-    ru: Шпицберген
-    si: ස්වාල්බාඩ්
-    sk: Svalbard
-    sl: Spitsbergi
-    sr: Свалбард
-    sv: Svalbard
-    sw: Svalbard
-    ta: சுவல்பார்டு
-    te: స్వాల్బార్డ్
-    th: สฟาลบาร์
-    tr: Svalbard
-    uk: Шпіцберген
-    ur: سوالبارد
-    vi: Svalbard
-'22':
-  translations:
-    af: Jan Mayen
-    ar: جان ماين
-    be: Востраў Ян-Маен
-    bg: Ян Майен
-    ca: Jan Mayen
-    cs: Jan Mayen
-    da: Jan Mayen
-    de: Jan Mayen
-    el: Γιαν Μαγιέν
-    en: Jan Mayen
-    es: Jan Mayen
-    et: Jan Mayen
-    eu: Jan Mayen
-    fa: یان ماین
-    fi: Jan Mayen
-    fr: Jan Mayen
-    gl: Jan Mayen
-    he: יאן מאיין
-    hi: यान मायेन
-    hr: Jan Mayen
-    hu: Jan Mayen-sziget
-    hy: Յան Մայեն
-    id: Jan Mayen
-    is: Jan Mayen
-    it: Jan Mayen
-    ja: ヤンマイエン島
-    ka: იან-მაიენი
-    ko: 얀마옌 섬
-    lt: Jan Majenas
-    lv: Jana Majena sala
-    mn: Ян-Майен
-    mr: यान मायेन
-    ms: Jan Mayen
-    nb: Jan Mayen
-    nl: Jan Mayen
-    pl: Jan Mayen
-    pt: Jan Mayen
-    ro: Insula Jan Mayen
-    ru: Ян-Майен
-    sk: Jan Mayen
-    sl: Jan Mayen
-    sr: Јан Мајен
-    sv: Jan Mayen
-    sw: Jan Mayen
-    ta: ஜான் மாயென்
-    th: ยานไมเอน
-    tr: Jan Mayen
-    uk: Ян-Маєн
-    ur: جان ماین
-    vi: Jan Mayen
-'08':
-  translations:
-    ar: مقاطعة تلمارك
-    be: Тэлемарк
-    bg: Телемарк
-    ca: Telemark
-    cs: Telemark
-    da: Telemarken
-    de: Telemark
-    en: Telemark
-    es: Telemark
-    et: Telemark
-    eu: Telemark
-    fa: تلمارک
-    fi: Telemarkin lääni
-    fr: Comté de Telemark
-    hr: Telemark
-    hu: Telemark megye
-    id: Telemark
-    is: Þelamörk
-    it: Telemark
-    ja: テレマルク県
-    ka: ტელემარკი
-    ko: 텔레마르크 주
-    lt: Telemarkas
-    nb: Telemark
-    nl: Telemark
-    pl: Telemark
-    pt: Telemark
-    ro: Telemark
-    ru: Телемарк
-    sk: Telemark
-    sl: Telemark
-    sr: Телемарк
-    sv: Telemark fylke
-    ta: டெலிமார்க்
-    tr: Telemark
-    uk: Телемарк
-    ur: تیلیمارک
-    vi: Telemark
-'09':
-  translations:
-    ar: أوست أغدر
-    be: Эўст-Агдэр
-    bg: Ауст-Агдер
-    ca: Aust-Agder
-    cs: Aust-Agder
-    da: Aust-Agder
-    de: Aust-Agder
-    en: Aust-Agder
-    es: Aust-Agder
-    et: Aust-Agder
-    eu: Aust-Agder
-    fa: اوست آدر
-    fi: Itä-Agderin lääni
-    fr: Comté d’Aust-Agder
-    hr: Aust-Agder
-    hu: Aust-Agder megye
-    id: Aust-Agder
-    is: Austur-Agðir
-    it: Aust-Agder
-    ja: アウスト・アグデル県
-    ka: ეუსტ-აგდერი
-    ko: 에우스트아그데르 주
-    lt: Rytų Agderis
-    nb: Aust-Agder
-    nl: Aust-Agder
-    pl: Aust-Agder
-    pt: Aust-Agder
-    ro: Aust-Agder
-    ru: Эуст-Агдер
-    sk: Aust-Agder
-    sl: Aust-Agder
-    sr: Источни Агдер
-    sv: Aust-Agder fylke
-    sw: Aust-Agder
-    tr: Aust-Agder
-    uk: Еуст-Аґдер
-    ur: آوست-آگدیر
-    vi: Aust-Agder
-'11':
-  translations:
-    ar: روغالاند
-    be: Ругалан
-    bg: Ругалан
-    ca: Rogaland
-    cs: Rogaland
-    da: Rogaland
-    de: Rogaland
-    en: Rogaland
-    es: Rogaland
-    et: Rogaland
-    eu: Rogaland
-    fa: روگالاند
-    fi: Rogalandin lääni
-    fr: comté de Rogaland
-    he: רוגלנד
-    hr: Rogaland
-    hu: Rogaland megye
-    hy: Ռուգլան
-    id: Rogaland
-    is: Rogaland
-    it: Rogaland
-    ja: ローガラン県
-    ka: რუგალანი
-    ko: 로갈란 주
-    lt: Rugalandas
-    lv: Rūgalanne
-    nb: Rogaland
-    nl: Rogaland
-    pl: Rogaland
-    pt: Rogaland
-    ro: Rogaland
-    ru: Ругаланн
-    sk: Rogaland
-    sl: Rogaland
-    sr: Рогаланд
-    sv: Rogaland fylke
-    sw: Rogaland
-    tr: Rogaland
-    uk: Руґалан
-    ur: روگالان
-    vi: Rogaland
+  geo:
+    latitude: 60.2733674
+    longitude: 5.7220194
+    min_latitude: 59.4759811
+    min_longitude: 4.6334781
+    max_latitude: 61.0352379
+    max_longitude: 7.732114699999999
+  name: Hordaland
 '14':
+  unofficial_names: Sogn og Fjordane
   translations:
     ar: سوغن و فيوردانه
     bg: Согн ог Фьоране
@@ -1183,7 +778,16 @@ NO-22:
     uk: Согн-ог-Фʼюране
     ur: سونگ او فیورانہ
     vi: Sogn og Fjordane
+  geo:
+    latitude: 61.5539435
+    longitude: 6.3325879
+    min_latitude: 60.67554759999999
+    min_longitude: 4.5000011
+    max_latitude: 62.2168708
+    max_longitude: 8.3220528
+  name: Sogn og Fjordane
 '15':
+  unofficial_names: Møre og Romsdal
   translations:
     ar: موره ورومسدال
     be: Мёрэ-ог-Румсдал
@@ -1224,7 +828,16 @@ NO-22:
     uk: Мере-ог-Ромсдал
     ur: مورہ او رومسدال
     vi: Møre og Romsdal
+  geo:
+    latitude: 62.9760369
+    longitude: 8.018272399999999
+    min_latitude: 61.9565835
+    min_longitude: 5.263584499999999
+    max_latitude: 63.5377568
+    max_longitude: 9.5842118
+  name: Møre og Romsdal
 '16':
+  unofficial_names: Sør-Trøndelag
   translations:
     ar: سور ترونديلاغ
     be: Сёр-Трондэлаг
@@ -1274,7 +887,16 @@ NO-22:
     uk: Сер-Тренделаг
     ur: جنوبی-تروندیلاگ
     vi: Sør-Trøndelag
+  geo:
+    latitude: 63.0136823
+    longitude: 10.3487135
+    min_latitude: 62.2557267
+    min_longitude: 8.233780099999999
+    max_latitude: 64.4653999
+    max_longitude: 12.2467012
+  name: Sør-Trøndelag
 '17':
+  unofficial_names: Nord-Trøndelag
   translations:
     ar: نور تروندلاغ
     be: Нур-Трондэлаг
@@ -1327,3 +949,318 @@ NO-22:
     uk: Нур-Тренделаг
     ur: شمالی-تروندیلاگ
     vi: Nord-Trøndelag
+  geo:
+    latitude: 64.4370792
+    longitude: 11.7462949
+    min_latitude: 63.1806873
+    min_longitude: 10.1335962
+    max_latitude: 65.39440379999999
+    max_longitude: 14.3259858
+  name: Nord-Trøndelag
+'18':
+  unofficial_names: Nordland
+  translations:
+    af: Nordland
+    ar: نورلان
+    be: Нурлан
+    bg: Норлан
+    bn: নর্ডল্যান্ড
+    ca: Nordland
+    cs: Nordland
+    da: Nordland
+    de: Nordland
+    el: Νόρντλαντ
+    en: Nordland
+    es: Nordland
+    et: Nordland
+    eu: Nordland
+    fa: نوردلند
+    fi: Nordlandin lääni
+    fr: comté de Nordland
+    gu: નોર્ડલેન્ડ
+    hi: नोर्डलैंड
+    hr: Nordland
+    hu: Nordland megye
+    hy: Նուռլան
+    id: Nordland
+    is: Norðurland
+    it: Nordland
+    ja: ヌールラン県
+    ka: ნურლანი
+    kn: ನಾರ್ಡ್ಲ್ಯಾಂಡ್
+    ko: 노를란 주
+    lt: Nordlandas
+    lv: Nūrlanne
+    mr: नोर्डंड
+    ms: Nordland
+    nb: Nordland
+    nl: Nordland
+    pl: Nordland
+    pt: Nordland
+    ro: Nordland
+    ru: Нурланн
+    si: නොර්ඩ්ලන්ඩ්
+    sk: Nordland
+    sl: Nordland
+    sr: Нордланд
+    sv: Nordland fylke
+    sw: Nordland
+    te: నార్డ్‌లాండ్
+    th: นอร์ดแลนด์
+    tr: Nordland
+    uk: Нурлан
+    ur: نودلان
+    vi: Nordland
+  geo:
+    latitude: 67.69167019999999
+    longitude: 12.7019476
+    min_latitude: 
+    min_longitude: 
+    max_latitude: 
+    max_longitude: 
+  name: Nordland
+'19':
+  unofficial_names: Troms
+  translations:
+    af: Troms
+    ar: ترومس
+    be: Тромс
+    bg: Тромс
+    bn: ট্রোমস
+    ca: Troms
+    cs: Troms
+    da: Troms
+    de: Troms
+    el: Τρομς
+    en: Troms
+    es: Troms
+    et: Troms
+    eu: Troms
+    fa: ترومز
+    fi: Tromssan lääni
+    fr: Troms
+    gu: ટ્રોમ્સ
+    hi: ट्रोम्स
+    hr: Troms
+    hu: Troms megye
+    hy: Թրոմս
+    id: Troms
+    is: Tromsfylki
+    it: Troms
+    ja: トロムス県
+    ka: ტრომსი
+    kn: ಟ್ರೋಮ್ಸ್
+    ko: 트롬스 주
+    lt: Trumsas
+    lv: Trumse
+    mr: ट्रॉम्स
+    ms: Troms
+    nb: Troms
+    nl: Troms
+    pl: Troms
+    pt: Troms
+    ro: Troms
+    ru: Тромс
+    si: ට්‍රොම්ස්
+    sk: Troms
+    sl: Troms
+    sr: Тромс
+    sv: Troms fylke
+    ta: ட்ரோம்ஸ்
+    te: ట్రోమ్స్
+    th: ตรอมส์
+    tr: Troms
+    uk: Трумс
+    ur: ترومس
+    vi: Troms
+  geo:
+    latitude: 69.81782419999999
+    longitude: 18.7819365
+    min_latitude: 68.3560138
+    min_longitude: 15.5925417
+    max_latitude: 70.31976139999999
+    max_longitude: 22.8944657
+  name: Troms
+'20':
+  unofficial_names:
+  - Finnmarku
+  translations:
+    af: Finnmark
+    ar: فينمارك
+    be: Фінмарк
+    bg: Финмарк
+    ca: Finnmark
+    cs: Finnmark
+    da: Finnmark
+    de: Finnmark
+    en: Finnmark
+    es: Finnmark
+    et: Finnmark
+    eu: Finnmark
+    fa: فینمارک
+    fi: Finnmarkin lääni
+    fr: comté de Finnmark
+    he: פינמרק
+    hr: Finnmark
+    hu: Finnmark megye
+    hy: Ֆինմարք
+    id: Finnmark
+    is: Finnmörk
+    it: Finnmark
+    ja: フィンマルク県
+    ka: ფინმარკი
+    ko: 핀마르크 주
+    lt: Finmarkas
+    lv: Finnmarka
+    nb: Finnmark
+    nl: Finnmark
+    pl: Finnmark
+    pt: Finnmark
+    ro: Finnmark
+    ru: Финнмарк
+    sk: Finnmark
+    sl: Finnmark
+    sr: Финмарк
+    sv: Finnmark fylke
+    sw: Finnmark
+    th: เทศมณฑลฟินน์มาร์ก
+    tr: Finnmark
+    uk: Фінмарк
+    ur: فنمارک
+    vi: Finnmark
+  geo:
+    latitude: 70.4830388
+    longitude: 26.0135108
+    min_latitude: 68.55459180000001
+    min_longitude: 21.173939
+    max_latitude: 71.1854762
+    max_longitude: 31.1682684
+  name: Finnmark
+'21':
+  unofficial_names: Svalbard (Arctic Region) (See also country code SJ)
+  translations:
+    af: Svalbard
+    ar: سفالبارد
+    az: Şpisbergen
+    be: Шпіцберген
+    bg: Шпицберген
+    bn: স্বালবার্ড
+    ca: Svalbard
+    cs: Špicberky
+    da: Svalbard
+    de: Spitzbergen
+    el: Αρχιπέλαγος Σβάλμπαρντ
+    en: Svalbard (Arctic Region) (See also country code SJ)
+    es: Svalbard
+    et: Svalbard
+    eu: Svalbard
+    fa: سوالبارد
+    fi: Huippuvuoret
+    fr: Svalbard
+    gl: Svalbard
+    gu: સ્વાલબાર્ડ
+    he: סבאלברד
+    hi: स्वालबार्ड
+    hr: Svalbard
+    hu: Spitzbergák
+    hy: Շպիցբերգեն
+    id: Svalbard
+    is: Svalbarði
+    it: Isole Svalbard
+    ja: スヴァールバル諸島
+    ka: შპიცბერგენი
+    kn: ಸ್ವಾಲ್ಬಾರ್ಡ್
+    ko: 스발바르 제도
+    lt: Svalbardas
+    lv: Svalbāra
+    ml: സ്വാൽബാർഡ്
+    mr: स्वालबार्ड
+    ms: Svalbard
+    nb: Svalbard
+    nl: Spitsbergen
+    pl: Svalbard
+    pt: Svalbard
+    ro: Svalbard
+    ru: Шпицберген
+    si: ස්වාල්බාඩ්
+    sk: Svalbard
+    sl: Spitsbergi
+    sr: Свалбард
+    sv: Svalbard
+    sw: Svalbard
+    ta: சுவல்பார்டு
+    te: స్వాల్బార్డ్
+    th: สฟาลบาร์
+    tr: Svalbard
+    uk: Шпіцберген
+    ur: سوالبارد
+    vi: Svalbard
+  geo:
+    latitude: 
+    longitude: 
+    min_latitude: 
+    min_longitude: 
+    max_latitude: 
+    max_longitude: 
+  name: Svalbard (Arctic Region) (See also country code SJ)
+'22':
+  unofficial_names: Jan Mayen (Arctic Region) (See also country code SJ)
+  translations:
+    af: Jan Mayen
+    ar: جان ماين
+    be: Востраў Ян-Маен
+    bg: Ян Майен
+    ca: Jan Mayen
+    cs: Jan Mayen
+    da: Jan Mayen
+    de: Jan Mayen
+    el: Γιαν Μαγιέν
+    en: Jan Mayen (Arctic Region) (See also country code SJ)
+    es: Jan Mayen
+    et: Jan Mayen
+    eu: Jan Mayen
+    fa: یان ماین
+    fi: Jan Mayen
+    fr: Jan Mayen
+    gl: Jan Mayen
+    he: יאן מאיין
+    hi: यान मायेन
+    hr: Jan Mayen
+    hu: Jan Mayen-sziget
+    hy: Յան Մայեն
+    id: Jan Mayen
+    is: Jan Mayen
+    it: Jan Mayen
+    ja: ヤンマイエン島
+    ka: იან-მაიენი
+    ko: 얀마옌 섬
+    lt: Jan Majenas
+    lv: Jana Majena sala
+    mn: Ян-Майен
+    mr: यान मायेन
+    ms: Jan Mayen
+    nb: Jan Mayen
+    nl: Jan Mayen
+    pl: Jan Mayen
+    pt: Jan Mayen
+    ro: Insula Jan Mayen
+    ru: Ян-Майен
+    sk: Jan Mayen
+    sl: Jan Mayen
+    sr: Јан Мајен
+    sv: Jan Mayen
+    sw: Jan Mayen
+    ta: ஜான் மாயென்
+    th: ยานไมเอน
+    tr: Jan Mayen
+    uk: Ян-Маєн
+    ur: جان ماین
+    vi: Jan Mayen
+  geo:
+    latitude: 
+    longitude: 
+    min_latitude: 
+    min_longitude: 
+    max_latitude: 
+    max_longitude: 
+  name: Jan Mayen (Arctic Region) (See also country code SJ)


### PR DESCRIPTION
I did something like this, but accounting for edge cases.
`(1..22).each { |i| [y["NO-#{i}"], y[i.to_s]].yield_self { |n, t| n['translations'] = t['translations'].merge(n['translations']).to_a.sort.to_h } }`
Then I removed `NO-` from the keys